### PR TITLE
Add traefik to compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,23 +70,23 @@ services:
   keycloak:
     image: jboss/keycloak
     environment:
-      DB_VENDOR: MYSQL
-      DB_ADDR: mysql
+      - DB_VENDOR=MYSQL
+      - DB_ADDR=mysql
       # Same values than the ones declared in mysql service.
-      DB_DATABASE: keycloak
-      DB_USER: keycloak
-      DB_PASSWORD: password
+      - DB_DATABASE=keycloak
+      - DB_USER=keycloak
+      - DB_PASSWORD=password
       # Change this seetings
-      KEYCLOAK_USER: admin # VERY IMPORTANT!
-      KEYCLOAK_PASSWORD: Pa55w0rd  # VERY IMPORTANT!
-      DB_VENDOR: MYSQL
+      - KEYCLOAK_USER=admin # VERY IMPORTANT!
+      - KEYCLOAK_PASSWORD=Pa55w0rd  # VERY IMPORTANT!
+      - DB_VENDOR=MYSQL
       # Uncomment the line below if you want to specify JDBC parameters.
       # The parameter below is just an example, and it shouldn't be used in production without knowledge.
       # It is highly recommended that you read the MySQL JDBC driver documentation in order to use it.
       #JDBC_PARAMS: "connectTimeout=30000"
-      PROXY_ADDRESS_FORWARDING: true
+      - PROXY_ADDRESS_FORWARDING=true
     ports:
-      - 8080:8080
+      - "8080:8080"
     depends_on:
       - mysql
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,27 +19,26 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
 
-  # app:
-    # build:
-    #   context: .
-    #   dockerfile: ./Dockerfile
-    # env_file: .env
-    # ports:
-    #   - 3000:3000
-    # depends_on:
-    #   - mongo
-    #   - mysql
-    #   - keycloak
-    # tty: true
-    # labels:
-    #   - "traefik.enable=true"
-    #   - "traefik.backend=app"
-    #   - "traefik.docker.network=back-tier"
-    #   - "traefik.frontend.entryPoints=http"
-    #   - "traefik.frontend.rule=Host:localhost;PathPrefix:/api"
-    #   - "traefik.port=3000"
-    # networks:
-    #   - back-tier
+  app:
+    build: .
+    image: democracyos/core:latest
+    env_file: .env.dist
+    ports:
+      - "3000:3000"
+    depends_on:
+      - mongo
+      - mysql
+      - keycloak
+    tty: true
+    labels:
+      - "traefik.enable=true"
+      - "traefik.backend=app"
+      - "traefik.docker.network=back-tier"
+      - "traefik.frontend.entryPoints=http"
+      - "traefik.frontend.rule=Host:localhost;PathPrefix:/api"
+      - "traefik.port=3000"
+    networks:
+      - back-tier
 
   mongo:
     image: mongo:3.6
@@ -79,7 +78,6 @@ services:
       # Change this seetings
       - KEYCLOAK_USER=admin # VERY IMPORTANT!
       - KEYCLOAK_PASSWORD=Pa55w0rd  # VERY IMPORTANT!
-      - DB_VENDOR=MYSQL
       # Uncomment the line below if you want to specify JDBC parameters.
       # The parameter below is just an example, and it shouldn't be used in production without knowledge.
       # It is highly recommended that you read the MySQL JDBC driver documentation in order to use it.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,20 @@ volumes:
     driver: local
 
 services:
+  traefik:
+    image: traefik
+    command: --api --docker
+    labels:
+      - "traefik.enable=false"
+    networks:
+      - front-tier
+      - back-tier
+    ports:
+      - "8000:80"
+      - "8080:8080"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+
   # app:
     # build:
     #   context: .
@@ -17,6 +31,15 @@ services:
     #   - mysql
     #   - keycloak
     # tty: true
+    # labels:
+    #   - "traefik.enable=true"
+    #   - "traefik.backend=app"
+    #   - "traefik.docker.network=back-tier"
+    #   - "traefik.frontend.entryPoints=http"
+    #   - "traefik.frontend.rule=Host:localhost;PathPrefix:/api"
+    #   - "traefik.port=3000"
+    # networks:
+    #   - back-tier
 
   mongo:
     image: mongo:3.6
@@ -25,35 +48,59 @@ services:
     # Optionally mount external data directory
     volumes:
       - ~/data3.2:/data/db
+    labels:
+      - "traefik.enable=false"
+    networks:
+      - back-tier
 
   mysql:
-      image: mysql:5.7
-      volumes:
-        - mysql_data:/var/lib/mysql
-      environment:
-        MYSQL_ROOT_PASSWORD: root
-        MYSQL_DATABASE: keycloak
-        MYSQL_USER: keycloak
-        MYSQL_PASSWORD: password
+    image: mysql:5.7
+    volumes:
+      - mysql_data:/var/lib/mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: keycloak
+      MYSQL_USER: keycloak
+      MYSQL_PASSWORD: password
+    networks:
+      - back-tier
+    labels:
+      - "traefik.enable=false"
 
   keycloak:
-      image: jboss/keycloak
-      environment:
-        DB_VENDOR: MYSQL
-        DB_ADDR: mysql
-        # Same values than the ones declared in mysql service.
-        DB_DATABASE: keycloak
-        DB_USER: keycloak
-        DB_PASSWORD: password
-        # Change this seetings
-        KEYCLOAK_USER: admin # VERY IMPORTANT!
-        KEYCLOAK_PASSWORD: Pa55w0rd  # VERY IMPORTANT!
-        DB_VENDOR: MYSQL
-        # Uncomment the line below if you want to specify JDBC parameters.
-        # The parameter below is just an example, and it shouldn't be used in production without knowledge.
-        # It is highly recommended that you read the MySQL JDBC driver documentation in order to use it.
-        #JDBC_PARAMS: "connectTimeout=30000"
-      ports:
-        - 8080:8080
-      depends_on:
-        - mysql
+    image: jboss/keycloak
+    environment:
+      DB_VENDOR: MYSQL
+      DB_ADDR: mysql
+      # Same values than the ones declared in mysql service.
+      DB_DATABASE: keycloak
+      DB_USER: keycloak
+      DB_PASSWORD: password
+      # Change this seetings
+      KEYCLOAK_USER: admin # VERY IMPORTANT!
+      KEYCLOAK_PASSWORD: Pa55w0rd  # VERY IMPORTANT!
+      DB_VENDOR: MYSQL
+      # Uncomment the line below if you want to specify JDBC parameters.
+      # The parameter below is just an example, and it shouldn't be used in production without knowledge.
+      # It is highly recommended that you read the MySQL JDBC driver documentation in order to use it.
+      #JDBC_PARAMS: "connectTimeout=30000"
+      PROXY_ADDRESS_FORWARDING: true
+    ports:
+      - 8080:8080
+    depends_on:
+      - mysql
+    labels:
+      - "traefik.enable=true"
+      - "traefik.backend=keycloak"
+      - "traefik.port=8080"
+      - "traefik.docker.network=back-tier"
+      - "traefik.frontend.entryPoints=http"
+      - "traefik.frontend.rule=Host:localhost;PathPrefix:/auth"
+    networks:
+      - back-tier
+
+networks:
+  front-tier:
+    driver: bridge
+  back-tier:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
   app:
     build: .
     image: democracyos/core:latest
-    env_file: .env.dist
+    env_file: .env
     ports:
       - "3000:3000"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,10 +83,10 @@ services:
       # It is highly recommended that you read the MySQL JDBC driver documentation in order to use it.
       #JDBC_PARAMS: "connectTimeout=30000"
       - PROXY_ADDRESS_FORWARDING=true
-    ports:
-      - "8080:8080"
     depends_on:
       - mysql
+    expose:
+      - "8080"
     labels:
       - "traefik.enable=true"
       - "traefik.backend=keycloak"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,10 +58,10 @@ services:
     volumes:
       - mysql_data:/var/lib/mysql
     environment:
-      MYSQL_ROOT_PASSWORD: root
-      MYSQL_DATABASE: keycloak
-      MYSQL_USER: keycloak
-      MYSQL_PASSWORD: password
+      - MYSQL_ROOT_PASSWORD=root
+      - MYSQL_DATABASE=keycloak
+      - MYSQL_USER=keycloak
+      - MYSQL_PASSWORD=password
     networks:
       - back-tier
     labels:


### PR DESCRIPTION
Add traefik as development http server. Routes enabled with this compose:
* http://localhost:8000/api -> DemocracyOS Core API.
* http://localhost:8000/auth -> Keycloak Service.