### PR TITLE
Adding General Comments for documents

### DIFF
--- a/api/document.js
+++ b/api/document.js
@@ -3,17 +3,26 @@ const express = require('express')
 const Document = require('../db-api/document')
 const GeneralComment = require('../db-api/generalComment')
 const CustomForm = require('../db-api/customForm')
-// const CustomFormVersion = require('../db-api/customFormVersion')
 const router = express.Router()
 const auth = require('../services/auth')
 const errors = require('../services/errors')
-const log = require('../services/logger')
 const middlewares = require('../services/middlewares')
-// const {
-//   ErrMissingParam,
-//   ErrNotFound,
-//   ErrParamTooLong
-// } = require('../services/errors')
+
+/**
+ * @apiDefine admin User access only
+ * User must be an admin (Keycloak)
+ */
+
+/**
+ * @apiDefine accountable Accountable members only
+ * User must be a member of the Accountable group (Keycloak)
+ */
+
+/**
+ * @apiDefine authenticated Must be authenticated
+ * User must be authenticated before accessing (Keycloak)
+ */
+
 router.route('/')
   /**
    * @api {get} /documents List
@@ -22,15 +31,21 @@ router.route('/')
    * @apiGroup Document
    */
   .get(
-    // auth.keycloak.protect('realm:accountable'),
     async (req, res, next) => {
       try {
-        const permissions = auth.getPermissions(req)
-        console.log(permissions)
-        const results = await Document.list({}, {
-          limit: req.query.limit,
-          page: req.query.page
-        })
+        let results = null
+        // If it is null, just show the published documents
+        if (req.query.myDocs !== undefined && auth.hasRealmRole(req, 'accountable')) {
+          results = await Document.list({ author: req.session.user._id }, {
+            limit: req.query.limit,
+            page: req.query.page
+          }) 
+        } else {
+          results = await Document.list({ published: true }, {
+            limit: req.query.limit,
+            page: req.query.page
+          })
+        }
         res.status(status.OK).json({
           results: results.docs,
           pagination: {
@@ -48,6 +63,7 @@ router.route('/')
    * @apiName postDocument
    * @apiDescription Creates a document and returns the created document. The author is not required to be sent on the body. API sets the author by itself.
    * @apiGroup Document
+   * @apiPermission accountable
    */
   .post(
     auth.keycloak.protect('realm:accountable'),
@@ -78,7 +94,6 @@ router.route('/:id')
    * @apiSuccess {String}  author  The user id of the author.
    * @apiSuccess {String}  published State of the document. If `false` is a draft and should not be public.
    * @apiSuccess {String}  customForm Id of the custom form
-   * @apiSuccess {Integer}  customFormVersion The current version of the custom form. Starts with 0. If it is <code>0</code> then its the first version of the custom form.
    * @apiSuccess {Date}  createdAt Date of creation
    * @apiSuccess {Date}  updatedAt Date of update
    * @apiSuccess {Object}  content Content of the document
@@ -114,7 +129,7 @@ router.route('/:id')
    * @apiName putDocument
    * @apiDescription Modifies a document. You just need to send the changed fields. No need to send all the document.
    * @apiGroup Document
-   *
+   * @apiPermission accountable
    * @apiParam {Number} id Documents ID.
    */
   .put(
@@ -141,8 +156,8 @@ router.route('/:id')
    * @api {delete} /documents/:id Delete
    * @apiName deleteDocument
    * @apiGroup Document
+   * @apiPermission accountable
    * @apiDescription Deletes a document and returns the id of the removed document.
-   * @apiParam {Number} id Documents ID.
    */
   .delete(
     middlewares.checkId,
@@ -162,11 +177,21 @@ router.route('/:id')
     })
 
 router.route('/:id/comments')
+  /**
+   * @api {get} /documents/:id/comments Get
+   * @apiName getGeneralComments
+   * @apiGroup GeneralComments
+   * @apiDescription Retrieves a paginated list of comments of a document
+   */
   .get(
     middlewares.checkId,
     async (req, res, next) => {
       try {
-        const results = await Document.listGeneralComments(req.params.id, {
+        let query = {
+          document: req.params.id
+        }
+        if (req.body.field) query.field = req.body.field
+        const results = await Document.listGeneralComments(query, {
           limit: req.query.limit,
           page: req.query.page
         })
@@ -183,6 +208,20 @@ router.route('/:id/comments')
       }
     }
   )
+  /**
+   * @api {post} /documents/:id/comments Create
+   * @apiName createComment
+   * @apiGroup GeneralComments
+   * @apiDescription Creates a comment on a specific field of a document.
+   * @apiPermission authenticated
+   * @apiParam {string} field (Body) The field of the document where the comment is being made
+   * @apiParam {Number} comment (Body) The field of the document where the comment is being made
+   * @apiExample {json} POST body
+   * {
+   *  "field": "authorName",
+   *  "comment": "Nullam sit amet ipsum id metus porta rutrum in vel nibh. Sed efficitur quam urna, eget imperdiet libero ornare."
+   * }
+   */
   .post(
     middlewares.checkId,
     auth.keycloak.protect(),

--- a/api/document.js
+++ b/api/document.js
@@ -39,7 +39,7 @@ router.route('/')
           results = await Document.list({ author: req.session.user._id }, {
             limit: req.query.limit,
             page: req.query.page
-          }) 
+          })
         } else {
           results = await Document.list({ published: true }, {
             limit: req.query.limit,
@@ -229,6 +229,11 @@ router.route('/:id/comments')
       try {
         req.body.user = req.session.user._id
         req.body.document = req.params.id
+        const document = await Document.get({ _id: req.params.id })
+        const customForm = await CustomForm.get({ _id: document.customForm })
+        if (!customForm.fields.allowComments.find((x) => { return x === req.body.field })) {
+          throw errors.ErrInvalidParam(`The field ${req.body.field} is not commentable`)
+        }
         const newGeneralComment = await GeneralComment.create(req.body)
         res.status(status.CREATED).send(newGeneralComment)
       } catch (err) {

--- a/db-api/document.js
+++ b/db-api/document.js
@@ -1,6 +1,7 @@
 const { Types: { ObjectId } } = require('mongoose')
 const { merge } = require('lodash/object')
 const Document = require('../models/document')
+const GeneralComment = require('../models/generalComment')
 const validator = require('../services/jsonSchemaValidator')
 const errors = require('../services/errors')
 
@@ -58,4 +59,14 @@ exports.remove = function remove (id) {
       if (!document) throw errors.ErrNotFound('Document to remove not found')
       document.remove()
     })
+}
+
+exports.listGeneralComments = function (documentId, { limit, page }) {
+  return GeneralComment
+    .paginate({ document: documentId }, { page, limit })
+}
+
+exports.listGeneralCommentsByField = function (documentId, field, { limit, page }) {
+  return GeneralComment
+    .paginate({ document: documentId, field: field }, { page, limit })
 }

--- a/db-api/document.js
+++ b/db-api/document.js
@@ -61,12 +61,7 @@ exports.remove = function remove (id) {
     })
 }
 
-exports.listGeneralComments = function (documentId, { limit, page }) {
+exports.listGeneralComments = function (query, { limit, page }) {
   return GeneralComment
-    .paginate({ document: documentId }, { page, limit })
-}
-
-exports.listGeneralCommentsByField = function (documentId, field, { limit, page }) {
-  return GeneralComment
-    .paginate({ document: documentId, field: field }, { page, limit })
+    .paginate(query, { page, limit })
 }

--- a/db-api/generalComment.js
+++ b/db-api/generalComment.js
@@ -4,50 +4,7 @@ const GeneralComment = require('../models/generalComment')
 // const validator = require('../services/jsonSchemaValidator')
 const errors = require('../services/errors')
 
-// exports.isAuthor = async function isAuthor (id, author) {
-//   let count = await GeneralComment.count({ _id: id, author: author })
-//   return count
-// }
-
 // Create generalComment
 exports.create = async function create (generalComment, customForm) {
   return (new GeneralComment(generalComment)).save()
 }
-
-// // Get generalComment
-// exports.get = function get (query) {
-//   return GeneralComment.findOne(query)
-// }
-
-// List general comments
-// exports.list = function list (query, { limit, page }) {
-//   return GeneralComment
-//     .paginate(query, { page, limit })
-// }
-
-// // Update generalComment
-// exports.update = async function update (id, generalComment, customForm) {
-//   // First, find if the generalComment exists
-//   return GeneralComment.findOne({ _id: id })
-//     .then((_generalComment) => {
-//       // Founded?
-//       if (!_generalComment) throw errors.ErrNotFound('GeneralComment to update not found')
-//       // Deep merge the change(s) with the generalComment
-//       let generalCommentToSave = merge(_generalComment, generalComment)
-//       // Validate the data
-//       validator.isDataValid(
-//         customForm.fields,
-//         generalCommentToSave.content.fields
-//       )
-//       // Save!
-//       return generalCommentToSave.save()
-//     })
-// }
-
-// exports.remove = function remove (id) {
-//   return GeneralComment.findOne({ _id: id })
-//     .then((generalComment) => {
-//       if (!generalComment) throw errors.ErrNotFound('GeneralComment to remove not found')
-//       generalComment.remove()
-//     })
-// }

--- a/db-api/generalComment.js
+++ b/db-api/generalComment.js
@@ -1,0 +1,53 @@
+const { Types: { ObjectId } } = require('mongoose')
+// const { merge } = require('lodash/object')
+const GeneralComment = require('../models/generalComment')
+// const validator = require('../services/jsonSchemaValidator')
+const errors = require('../services/errors')
+
+// exports.isAuthor = async function isAuthor (id, author) {
+//   let count = await GeneralComment.count({ _id: id, author: author })
+//   return count
+// }
+
+// Create generalComment
+exports.create = async function create (generalComment, customForm) {
+  return (new GeneralComment(generalComment)).save()
+}
+
+// // Get generalComment
+// exports.get = function get (query) {
+//   return GeneralComment.findOne(query)
+// }
+
+// List general comments
+// exports.list = function list (query, { limit, page }) {
+//   return GeneralComment
+//     .paginate(query, { page, limit })
+// }
+
+// // Update generalComment
+// exports.update = async function update (id, generalComment, customForm) {
+//   // First, find if the generalComment exists
+//   return GeneralComment.findOne({ _id: id })
+//     .then((_generalComment) => {
+//       // Founded?
+//       if (!_generalComment) throw errors.ErrNotFound('GeneralComment to update not found')
+//       // Deep merge the change(s) with the generalComment
+//       let generalCommentToSave = merge(_generalComment, generalComment)
+//       // Validate the data
+//       validator.isDataValid(
+//         customForm.fields,
+//         generalCommentToSave.content.fields
+//       )
+//       // Save!
+//       return generalCommentToSave.save()
+//     })
+// }
+
+// exports.remove = function remove (id) {
+//   return GeneralComment.findOne({ _id: id })
+//     .then((generalComment) => {
+//       if (!generalComment) throw errors.ErrNotFound('GeneralComment to remove not found')
+//       generalComment.remove()
+//     })
+// }

--- a/models/community.js
+++ b/models/community.js
@@ -13,7 +13,7 @@ const Community = new mongoose.Schema({
 let autoPopulate = function (next) {
   this.populate('userProfileSchema')
   next()
-};
+}
 
 Community
   .pre('findOne', autoPopulate)

--- a/models/customForm.js
+++ b/models/customForm.js
@@ -16,7 +16,9 @@ const CustomForm = new mongoose.Schema({
       }
     ],
     properties: { type: mongoose.Schema.Types.Mixed },
-    required: [{ type: String }]
+    required: [{ type: String }],
+    richText: [{ type: String }],
+    allowComments: [{ type: String }]
   }
 }, {
   timestamps: true

--- a/models/generalComment.js
+++ b/models/generalComment.js
@@ -1,0 +1,15 @@
+const mongoose = require('mongoose')
+const mongoosePaginate = require('mongoose-paginate')
+
+const GeneralComment = new mongoose.Schema({
+  user: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+  document: { type: mongoose.Schema.Types.ObjectId, ref: 'Document' },
+  field: { type: String },
+  comment: { type: String }
+}, { timestamps: true })
+
+// Model's Plugin Extensions
+GeneralComment.plugin(mongoosePaginate)
+
+// Expose `User` Model
+module.exports = mongoose.model('GeneralComment', GeneralComment)

--- a/seed.js
+++ b/seed.js
@@ -90,6 +90,12 @@ async function startSetup () {
               'authorEmail'
             ],
             'name': 'About the author'
+          },
+          {
+            'fields': [
+              'introduction'
+            ],
+            'name': 'The text itself'
           }
         ],
         properties: {
@@ -104,13 +110,20 @@ async function startSetup () {
           'authorEmail': {
             type: 'string',
             title: "Author's email"
+          },
+          'introduction': {
+            'type': 'string',
+            'title': 'A small introduction'
           }
         },
         required: [
           'authorName',
           'authorSurname',
-          'authorEmail'
-        ]
+          'authorEmail',
+          'introduction'
+        ],
+        richText: ['introduction'],
+        allowComments: ['introduction']
       }
     })
     log.debug('--> OK')

--- a/services/mongoose.js
+++ b/services/mongoose.js
@@ -20,6 +20,7 @@ require('../models/user')
 require('../models/community')
 require('../models/customForm')
 require('../models/document')
+require('../models/generalComment')
 
 const db = mongoose.connection
 

--- a/test/api/document.js
+++ b/test/api/document.js
@@ -194,7 +194,7 @@ describe('Documents API (/api/v1/documents)', () => {
           throw err
         })
     })
-    it('POST (/:id/comments) should be able to create a comment on a specific document, in a specific field', async () => {
+    it('POST (/:id/comments) should be able to create a comment on a specific document, of a specific field', async () => {
       let fakeComment = fake.generalComment()
       await agent.post(`/api/v1/documents/${newDocument1._id}/comments`)
         .set('Authorization', 'Bearer ' + accessToken)

--- a/test/api/document.js
+++ b/test/api/document.js
@@ -3,6 +3,7 @@ const chaiHttp = require('chai-http')
 const status = require('http-status')
 const Document = require('../../models/document')
 const CustomForm = require('../../models/customForm')
+const GeneralComment = require('../../models/generalComment')
 const config = require('../../config')
 const fake = require('../fake')
 
@@ -32,6 +33,7 @@ describe('Documents API (/api/v1/documents)', () => {
     // That is, clean the database, or initialize anything you need before executing the suite of tests
     await CustomForm.remove({})
     await Document.remove({})
+    await GeneralComment.remove({})
     newCustomForm = await (new CustomForm(fakeCustomForm)).save()
     fakeDocument1 = fake.document(true, true, null, newCustomForm.id)
     fakeDocument2 = fake.document(true, false, null, newCustomForm.id)
@@ -165,7 +167,7 @@ describe('Documents API (/api/v1/documents)', () => {
       expect(documentsCreated).to.be.most(10)
     })
     it('GET (/) The author should be able to list its own documents, drafts or published', async () => {
-      await agent.get('/api/v1/documents')
+      await agent.get('/api/v1/documents?myDocs')
         .set('Authorization', 'Bearer ' + accessToken)
         .set('X-Requested-With', 'XMLHttpRequest')
         .set('Content-Type', 'application/json')
@@ -192,7 +194,56 @@ describe('Documents API (/api/v1/documents)', () => {
           throw err
         })
     })
+    it('POST (/:id/comments) should be able to create a comment on a specific document, in a specific field', async () => {
+      let fakeComment = fake.generalComment()
+      await agent.post(`/api/v1/documents/${newDocument1._id}/comments`)
+        .set('Authorization', 'Bearer ' + accessToken)
+        .set('X-Requested-With', 'XMLHttpRequest')
+        .set('Content-Type', 'application/json')
+        .send(fakeComment)
+        .then((res) => {
+          expect(res).to.have.status(status.CREATED)
+          /* eslint-disable no-unused-expressions */
+          expect(res.body).to.not.be.null
+          expect(res.body).to.have.property('document')
+          expect(res.body).to.have.property('user')
+          expect(res.body).to.have.property('field')
+          expect(res.body).to.have.property('comment')
+          expect(res.body).to.have.property('createdAt')
+          expect(res.body).to.have.property('updatedAt')
+        })
+        .catch((err) => {
+          // expect(err).to.have.status(status.FORBIDDEN)
+          throw err
+        })
+    })
+    it('GET (/:id/comments) should be able to get a list of comments of a specific document', async () => {
+      await agent.get(`/api/v1/documents/${newDocument1._id}/comments`)
+        .set('Authorization', 'Bearer ' + accessToken)
+        .set('X-Requested-With', 'XMLHttpRequest')
+        .set('Content-Type', 'application/json')
+        .then((res) => {
+          expect(res).to.have.status(status.OK)
+          const { results, pagination } = res.body
+          expect(results).to.be.a('array')
+          expect(results.length).to.be.least(1)
+          expect(results[0]).to.have.property('document')
+          expect(results[0]).to.have.property('user')
+          expect(results[0]).to.have.property('field')
+          expect(results[0]).to.have.property('comment')
+          expect(results[0]).to.have.property('createdAt')
+          expect(results[0]).to.have.property('updatedAt')
+          expect(pagination).to.have.property('count')
+          expect(pagination).to.have.property('page')
+          expect(pagination).to.have.property('limit')
+        })
+        .catch((err) => {
+          // expect(err).to.have.status(status.FORBIDDEN)
+          throw err
+        })
+    })
     it('GET (/:id) it should be to retrieve a document', async () => {
+          console.log(`/api/v1/documents/${newDocument4._id}`)
       await agent.get(`/api/v1/documents/${newDocument4._id}`)
         .set('Authorization', 'Bearer ' + accessToken)
         .set('X-Requested-With', 'XMLHttpRequest')

--- a/test/db-api/generalComment.js
+++ b/test/db-api/generalComment.js
@@ -1,0 +1,40 @@
+const { expect } = require('chai')
+const rewire = require('rewire')
+const sinon = require('sinon')
+require('sinon-mongoose')
+const { Types: { ObjectId } } = require('mongoose')
+const fake = require('../fake')
+
+const GeneralComment = require('../../models/generalComment')
+const generalComment = require('../../db-api/generalComment')
+
+const generalCommentSample = fake.generalComment()
+
+describe('GeneralComment DB-APIs', () => {
+  // ===================================================
+  it('GeneralComment.create() should create a generalComment', () => {
+    // require module with rewire to override its internal GeneralComment reference
+    const generalComment = rewire('../../db-api/generalComment')
+
+    // replace GeneralComment constructor for a spy
+    const GeneralCommentMock = sinon.spy()
+
+    // add a save method that only returns the data
+    GeneralCommentMock.prototype.save = () => { return Promise.resolve(generalCommentSample) }
+
+    // create a spy for the save method
+    const save = sinon.spy(GeneralCommentMock.prototype, 'save')
+
+    // override GeneralComment inside `generalComment/db-api/generalComment`
+    generalComment.__set__('GeneralComment', GeneralCommentMock)
+
+    // call create method
+    return generalComment.create(generalCommentSample)
+      .then((result) => {
+        sinon.assert.calledWithNew(GeneralCommentMock)
+        sinon.assert.calledWith(GeneralCommentMock, generalCommentSample)
+        sinon.assert.calledOnce(save)
+        expect(result).to.equal(generalCommentSample)
+      })
+  })
+})

--- a/test/fake.js
+++ b/test/fake.js
@@ -86,6 +86,12 @@ const customForm = (valid) => {
             'orgAdress',
             'orgTel'
           ]
+        },
+        {
+          name: 'The content info',
+          fields: [
+            'introduction'
+          ]
         }
       ],
       properties: {
@@ -112,20 +118,29 @@ const customForm = (valid) => {
         'orgAdress': {
           type: 'string',
           title: "Org's address"
+        },
+        'introduction': {
+          type: 'string',
+          title: 'Some introduction'
         }
       },
       required: [
         'authorName',
         'authorSurname',
-        'authorEmail'
+        'authorEmail',
+        'introduction'
+      ],
+      richText: ['introduction'],
+      allowComments: [
+        'introduction'
       ]
     }
   }
 }
 
-const document = (valid, published, author, customFormId) => {
+const document = (valid, published, authorId, customFormId) => {
   return {
-    author: author || null,
+    author: authorId || '5b9297921388502c145a952e',
     published: published || false,
     customForm: customFormId || null,
     content: {
@@ -135,9 +150,17 @@ const document = (valid, published, author, customFormId) => {
         authorName: valid !== undefined && !valid ? faker.random.number() : faker.name.firstName(),
         authorSurname: faker.name.lastName(),
         authorEmail: faker.internet.email(),
-        orgTel: valid !== undefined && !valid ? faker.random.number() : faker.company.companyName()
+        orgTel: valid !== undefined && !valid ? faker.random.number() : faker.company.companyName(),
+        introduction: faker.lorem.paragraphs(3)
       }
     }
+  }
+}
+
+const generalComment = (documentId, userId, field) => {
+  return {
+    field: field || 'introduction',
+    comment: faker.lorem.sentence(12)
   }
 }
 
@@ -145,6 +168,7 @@ module.exports = {
   community,
   customForm,
   document,
+  generalComment,
   userProfileSchema,
   userProfileCustomForm,
   user


### PR DESCRIPTION
- Added `richText` and `allowComments` to `customForms`. It declares which fields has richText and which fields allows comments. This will be handy later for validations and also for the front end to render proper components for that.
- Created model `generalComment`. It saves a comment related to a field of a document
- Added new db-apis: `Document.listGeneralComments( query )` and `GeneralComment.create( theGeneralComment )`
- Added 2 new API endpoints

| URI | Description | Auth |
| --- | --- | --- |
| `GET /api/v1/documents/:id/comments` | Retrieves a list of comments of the documents. | - |
| `POST /api/v1/documents/:id/comments` | Creates a new comment in a document. The request body requires 2 fields: `field` and `comment`. The `field` is part of the fields of customForm. First, during a POST request, it validates if the `field` is part of the `allowComments` array of the customForm of the document. If not, it throws an Exception. If everything is ok, the comment is saved | authenticated | 

- Updated API documentation
- Added 2 new tests under the documents test: 
`POST (/:id/comments) should be able to create a comment on a specific document, in a specific field`
`GET (/:id/comments) should be able to get a list of comments of a specific document`

Note: I might play around with [mocha-steps](https://www.npmjs.com/package/mocha-steps) cause I am having some issues with a POST and GET test.. Sometimes I need the POST to end properly before the GET and right now it does it job but a few times it fails. 